### PR TITLE
Update for latest Rails defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,15 @@ Field1 and field2 are the options you want the author to be able to
 enter data for. The generator will create the cell and the display and
 options view as well as add itself to the snippet_list partial.
 
+Contributing
+============
+
+To run the test suite for CMSimple, you will need to do the following:
+
+1. Setup the DB for testing
+  1. Configure a `database.yml` in the demo rails app6 (see spec/rails_app/config/database.example.yml)
+  2. Run setup tasks: `rake app:db:setup` and `rake app:db:test:prepare`
+2. Run specs
+  1. `rake spec`
+  2. Wait.
+

--- a/cmsimple.gemspec
+++ b/cmsimple.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "rails", "~> 3.2.1"
-  s.add_runtime_dependency 'jquery-rails', "~> 2.0.2"
+  s.add_runtime_dependency 'jquery-rails', "~> 2.1.3"
   s.add_runtime_dependency "mercury-rails"
   s.add_runtime_dependency "cells", "~> 3.8"
   s.add_runtime_dependency "carrierwave", "~> 0.5.8"

--- a/features/step_definitions/jasmine_runner.rb
+++ b/features/step_definitions/jasmine_runner.rb
@@ -3,5 +3,5 @@ Then /all jasmine specs should pass/ do
   wait_until 10 do
     page.evaluate_script('jasmine.getEnv().reporter.subReporters_[1].finished') == true
   end
-  page.should have_css(".runner.passed", :visible => true)
+  page.should have_css(".bar.passingAlert", :visible => true)
 end


### PR DESCRIPTION
I created a new Rails project with no modifications (i.e. `rails new PROJECT_NAME`) and got the following error when adding cmsimple to the gemfile and running `bundle install`

```
In Gemfile:
   cmsimple (>= 0) ruby depends on
     jquery-rails (~> 2.0.2) ruby

   jquery-rails (2.1.3)
```

I updated and added instructions on how to setup an environment for running the cmsimple test suite as I also had a bit of confusion with getting the specs running to ensure everything worked properly.
