### PR TITLE
Rescue the redirection to give the path a second chance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .bundle
+vendor/ruby
 .idea
 .rake_tasks
 .rvmrc

--- a/app/controllers/cmsimple/front_controller.rb
+++ b/app/controllers/cmsimple/front_controller.rb
@@ -16,7 +16,7 @@ module Cmsimple
     end
 
     def current_path
-      @path ||= Path.from_request(params[:path])
+      @path ||= Path.from_request!(request)
     end
 
     def current_page

--- a/app/controllers/cmsimple/pages_controller.rb
+++ b/app/controllers/cmsimple/pages_controller.rb
@@ -69,7 +69,7 @@ module Cmsimple
 
     #helpers
     def current_path
-      @path ||= Path.from_request(params[:path])
+      @path ||= Path.from_request!(request)
     end
 
     def current_page

--- a/app/models/cmsimple/path.rb
+++ b/app/models/cmsimple/path.rb
@@ -11,19 +11,16 @@ module Cmsimple
 
     before_validation :downcase_uri
 
-    def self.from_request(request, raise_error=false)
+    def self.from_request(request)
       if request.fullpath == '/'
         with_pages.merge(Cmsimple::Page.root).first
       elsif result = find_from_request(request)
         result
-      else
-        raise ActiveRecord::RecordNotFound.new if raise_error
       end
-
     end
 
     def self.from_request!(request)
-      from_request(request, true)
+      from_request(request) || raise(ActiveRecord::RecordNotFound.new)
     end
 
     def self.with_pages

--- a/features/create.feature
+++ b/features/create.feature
@@ -11,7 +11,7 @@ Feature: As a user I should be able to create pages on the site
     Then I should be redirected to the new page
     And I should see the page in the sitemap
 
-  Scenario: As a user I add a page from the sitemap panel
+  Scenario: As a user I add a new home page from the sitemap panel
     When I open the sitemap
     And I add a new home page
     Then I should be redirected to the home page

--- a/spec/models/path_spec.rb
+++ b/spec/models/path_spec.rb
@@ -119,17 +119,12 @@ describe Cmsimple::Path do
   describe "#from_request!" do
     let(:request) { ActionDispatch::TestRequest.new }
 
-    after { Cmsimple::Path.unstub(:from_request) }
-
-    it "calls the #from_request method" do
-      Cmsimple::Path.expects(:from_request).with(request, true)
-      Cmsimple::Path.from_request!(request)
-    end
-
-    it "raises ActiveRecord::RecordNotFound if no records are found" do
-      request.expects(:fullpath).returns('/foo').at_least_once
-      request.expects(:params).returns(path: '/foo').at_least_once
+    it "raises ActiveRecord::RecordNotFound when no records are found" do
+      Cmsimple::Path.should_receive(:from_request).with(request).and_return(nil)
+      request.stub(:fullpath).and_return('/foo')
+      request.stub(:params).and_return(path: '/foo')
       expect { Cmsimple::Path.from_request!(request) }.to raise_error ActiveRecord::RecordNotFound
     end
+
   end
 end

--- a/spec/models/path_spec.rb
+++ b/spec/models/path_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
+
 describe Cmsimple::Path do
+
   subject { Cmsimple::Path.new }
+
   it { should validate_presence_of(:uri) }
   it { should belong_to(:page) }
 
@@ -38,14 +41,14 @@ describe Cmsimple::Path do
 
   describe '#from_request' do
 
-    let(:request) { ActionDispatch::TestRequest.new() }
+    let(:request) { ActionDispatch::TestRequest.new }
 
-    context "does not find a path to follow" do
+    context "when there is no path to follow" do
       before do
-        request.expects(:fullpath).returns('/foo').at_least_once
-        request.expects(:params).returns(path: '/path')
+        request.stub(:fullpath).and_return('/foo')
+        request.stub(:params).and_return(path: '/path')
       end
-      it "does not raise and error" do
+      it "does not raise an error" do
         expect(Cmsimple::Path.from_request(request)).to_not raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -54,10 +57,10 @@ describe Cmsimple::Path do
       end
     end
 
-    context "default: finding the path via fullpath" do
+    context "when a path exists that matches the full request path" do
 
       it "finds the redirect" do
-        request.expects(:fullpath).returns('/path').at_least_once
+        request.stub(:fullpath).and_return('/path')
         subject.uri = '/path'
         subject.redirect_uri = '/some-other-path'
         subject.save
@@ -65,21 +68,21 @@ describe Cmsimple::Path do
       end
 
       it "finds the redirect when the path has an extension" do
-        request.expects(:fullpath).returns('/LegacyCrap.aspx').at_least_once
-        subject.uri = '/LegacyCrap.aspx'
+        request.stub(:fullpath).and_return('/Legacy.aspx')
+        subject.uri = '/Legacy.aspx'
         subject.redirect_uri = '/some-other-path'
         subject.save
         expect(Cmsimple::Path.from_request(request).destination.uri).to eq('/some-other-path')
       end
     end
 
-    context "cant find the path via fullpath" do
+    context "when a path exists that matches the globbed request path" do
       before do
-        request.expects(:fullpath).returns('/foo').at_least_once
+        request.stub(:fullpath).and_return('/foo')
       end
 
       it 'returns the path that has a uri matching the request path' do
-        request.expects(:params).returns(path: '/path')
+        request.stub(:params).and_return(path: '/path')
         subject.uri = '/path'
         subject.redirect_uri = '/some-other-path'
         subject.save
@@ -89,14 +92,14 @@ describe Cmsimple::Path do
       it "returns the path with the associated page" do
         page = Cmsimple::Page.create title: 'About'
         Cmsimple::Path.create uri: '/about', page: page
-        request.expects(:params).returns(path: '/about')
+        request.stub(:params).and_return(path: '/about')
         Cmsimple::Path.from_request(request).destination.title.should == 'About'
       end
 
       it "returns the path where the associated page is marked as root" do
         page = Cmsimple::Page.create title: 'Home', is_root: true
         Cmsimple::Path.create uri: '/home', page: page
-        request.expects(:params).returns(path: '/home')
+        request.stub(:params).and_return(path: '/home')
         Cmsimple::Path.from_request(request).destination.title.should == 'Home'
       end
 
@@ -104,13 +107,13 @@ describe Cmsimple::Path do
         subject.uri = '/path'
         subject.redirect_uri = '/some-other-path'
         subject.save
-        request.expects(:params).returns(path: '//path')
+        request.stub(:params).and_return(path: '//path')
         Cmsimple::Path.from_request(request).destination.uri.should == '/some-other-path'
-        request.expects(:params).returns(path: '//path/')
+        request.stub(:params).and_return(path: '//path/')
         Cmsimple::Path.from_request(request).destination.uri.should == '/some-other-path'
-        request.expects(:params).returns(path: 'path')
+        request.stub(:params).and_return(path: 'path')
         Cmsimple::Path.from_request(request).destination.uri.should == '/some-other-path'
-        request.expects(:params).returns(path: '/Path')
+        request.stub(:params).and_return(path: '/Path')
         Cmsimple::Path.from_request(request).destination.uri.should == '/some-other-path'
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ RSpec.configure do |config|
   # config.mock_with :mocha
   # config.mock_with :flexmock
   # config.mock_with :rr
-  # config.mock_with :rspec
+  config.mock_with :rspec
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
- redirect was not working on paths with extensions
- Cmsimple::Path#from_request was raising RecordNotFound and
  not looking to the request for the fullpath

@gvarela I wasn't sure how you felt about this solution. on one hand, it seems a little clunky for the model not to handle the RecordNotFound, on the other, I think its a little more robust to look to the request object itself to find the :fullpath in order to make the uri comparison since when a Redirection is created it seems that people type the entire relative url, like `/MyPage.aspx`. anyway, this seems to work, but I'm happy to revisit if you have concerns.
