### PR TITLE
Update dependency level for jquery-rails.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'mysql2'
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source :rubygems
 
 gem 'mysql2'
-gem 'jquery-rails'
 
 gem 'multi_json', '>= 1.3.4'
 

--- a/cmsimple.gemspec
+++ b/cmsimple.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "rails", "~> 3.2.1"
-  s.add_runtime_dependency 'jquery-rails', "~> 2.1.3"
+  s.add_runtime_dependency 'jquery-rails', "~> 2.2.0"
   s.add_runtime_dependency "mercury-rails"
   s.add_runtime_dependency "cells", "~> 3.8"
   s.add_runtime_dependency "carrierwave", "~> 0.5.8"

--- a/cmsimple.gemspec
+++ b/cmsimple.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency "rails", "~> 3.2.1"
-  s.add_runtime_dependency 'jquery-rails', "~> 2.2.0"
+  s.add_runtime_dependency 'jquery-rails'
   s.add_runtime_dependency "mercury-rails"
   s.add_runtime_dependency "cells", "~> 3.8"
   s.add_runtime_dependency "carrierwave", "~> 0.5.8"

--- a/lib/cmsimple/version.rb
+++ b/lib/cmsimple/version.rb
@@ -1,3 +1,3 @@
 module Cmsimple
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end


### PR DESCRIPTION
This is blocking the front end from upgrading anything past jQuery 1.8.3. Do
we even need the version in here?
